### PR TITLE
docs: bump go ver for contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing! This guide covers everything you ne
 
 ## Prerequisites
 
-- Go 1.22+
+- Go 1.26+
 - `kubectl` configured against a cluster (for manual testing)
 - [Kind](https://kind.sigs.k8s.io/) (for e2e tests)
 - Docker (for building images and e2e tests)


### PR DESCRIPTION
## Motivation

Go version was bumped to 1.26, this will sync the documentation to follow along.

## Checklist

- [x] Docs updated if behaviour changed

