### PR TITLE
feat: add hpa support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ go.work.sum
 # Editor/IDE
 .idea
 .vscode
+.zed
 *.swp
 *.swo
 *~

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ helm-crds: manifests ## Sync generated CRDs into the Helm chart directory.
 
 .PHONY: helm-rbac-check
 helm-rbac-check: ## Verify Helm chart ClusterRole rules are in sync with config/rbac/role.yaml.
-	python3 hack/check-helm-rbac.py
+	if command -v uv > /dev/null 2>&1; then uv run hack/check-helm-rbac.py; else python3 hack/check-helm-rbac.py; fi
 
 .PHONY: helm-sync
 helm-sync: helm-crds helm-rbac-check ## Sync CRDs and verify RBAC rules into the Helm chart (run after 'make manifests').

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ When business hours resume, LightsOut restores workloads to their original repli
 ## Features
 
 - **Cron-based scheduling** with IANA timezone support
-- **Manages Deployments, StatefulSets, and CronJobs** — scales replicas to zero or suspends CronJobs
-- **Flexible namespace targeting** — label selectors, explicit lists, and exclusions
-- **Namespace-scoped schedules** — developers can define their own schedules per namespace, independent of global schedules
-- **Rate-limited scaling** — batch workloads to avoid resource spikes
-- **Admission webhooks** — validates schedules and detects overlaps before they're applied
-- **ArgoCD integration** — optional labeling of ArgoCD Application CRDs to prevent false alerts during downscale
-- **Prometheus metrics** — observe schedule state, scaling operations, errors, and durations
+- **Manages Deployments, StatefulSets, and CronJobs** - scales replicas to zero or suspends CronJobs
+- **HPA-aware scaling** - automatically patches `spec.minReplicas` on attached HorizontalPodAutoscalers to prevent fight-back, then restores on upscale
+- **Flexible namespace targeting** - label selectors, explicit lists, and exclusions
+- **Namespace-scoped schedules** - developers can define their own schedules per namespace, independent of global schedules
+- **Rate-limited scaling** - batch workloads to avoid resource spikes
+- **Admission webhooks** - validates schedules and detects overlaps before they're applied
+- **ArgoCD integration** - optional labeling of ArgoCD Application CRDs to prevent false alerts during downscale
+- **Prometheus metrics** - observe schedule state, scaling operations, errors, and durations
 
 ## Quick Start
 
@@ -78,8 +79,8 @@ For production setups with webhook validation, see the [Setup Guide](docs/setup-
 
 LightsOut runs as a controller that watches two custom resource types:
 
-- **`LightsOutSchedule`** (cluster-scoped) — for platform teams managing cost policies across multiple namespaces. Supports label selectors and explicit namespace lists.
-- **`LightsOutNamespaceSchedule`** (namespace-scoped) — for developers who want to define their own schedule for their namespace. When a namespace schedule exists, any global schedule targeting that namespace automatically skips it.
+- **`LightsOutSchedule`** (cluster-scoped) - for platform teams managing cost policies across multiple namespaces. Supports label selectors and explicit namespace lists.
+- **`LightsOutNamespaceSchedule`** (namespace-scoped) - for developers who want to define their own schedule for their namespace. When a namespace schedule exists, any global schedule targeting that namespace automatically skips it.
 
 On each reconciliation, the controller calculates whether the current time falls in an "up" or "down" period based on your cron expressions, discovers target namespaces and workloads, and scales accordingly. Original replica counts are stored in annotations so they can be restored exactly.
 
@@ -110,7 +111,7 @@ At least one of `namespaceSelector` or `namespaces` must be specified.
 
 ### `LightsOutNamespaceSchedule` (namespace-scoped)
 
-Created by developers in their own namespace. No namespace selection fields — the schedule always manages the namespace it lives in. Supports all the same scheduling fields as `LightsOutSchedule`.
+Created by developers in their own namespace. No namespace selection fields - the schedule always manages the namespace it lives in. Supports all the same scheduling fields as `LightsOutSchedule`.
 
 ```yaml
 apiVersion: lightsout.techsupport.mk/v1alpha1
@@ -193,12 +194,13 @@ This approach also works with [Cluster Autoscaler](https://github.com/kubernetes
 
 ## Documentation
 
-- [Architecture](docs/architecture.md) — how LightsOut works internally
-- [ArgoCD Integration](docs/argocd.md) — prevent false alerts when scaling down
-- [Setup Guide](docs/setup-guide.md) — installation with and without webhooks
-- [Security Model](docs/security-model.md) — RBAC, risks, and mitigations
-- [Examples](examples/) — sample schedule configurations
+- [Architecture](docs/architecture.md) - how LightsOut works internally
+- [HPA Integration](docs/hpa.md) - automatic HorizontalPodAutoscaler handling
+- [ArgoCD Integration](docs/argocd.md) - prevent false alerts when scaling down
+- [Setup Guide](docs/setup-guide.md) - installation with and without webhooks
+- [Security Model](docs/security-model.md) - RBAC, risks, and mitigations
+- [Examples](examples/) - sample schedule configurations
 
 ## License
 
-Apache License 2.0 — see [LICENSE](LICENSE) for details.
+Apache License 2.0 - see [LICENSE](LICENSE) for details.

--- a/charts/lightsout/templates/clusterrole.yaml
+++ b/charts/lightsout/templates/clusterrole.yaml
@@ -67,6 +67,17 @@ rules:
       - patch
       - update
   {{- end }}
+  # HorizontalPodAutoscalers
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
   # CronJobs
   - apiGroups:
       - batch
@@ -78,9 +89,17 @@ rules:
       - watch
       - patch
       - update
-  # Events
+  # Events (core API group, legacy)
   - apiGroups:
       - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  # Events (events.k8s.io API group, used by controller-runtime's event broadcaster)
+  - apiGroups:
+      - events.k8s.io
     resources:
       - events
     verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,18 +7,19 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - namespaces
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -34,6 +35,16 @@ rules:
   - argoproj.io
   resources:
   - applications
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
   verbs:
   - get
   - list

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,8 +10,8 @@ Kubernetes cost optimization has two layers:
 
 ```mermaid
 flowchart TD
-    LO["<b>Workload Layer — LightsOut</b><br/>Scales Deployments, StatefulSets, CronJobs<br/>to zero during off-hours"]
-    K["<b>Node Layer — Karpenter / Cluster Autoscaler</b><br/>Detects empty nodes and deprovisions them"]
+    LO["<b>Workload Layer - LightsOut</b><br/>Scales Deployments, StatefulSets, CronJobs<br/>to zero during off-hours"]
+    K["<b>Node Layer - Karpenter / Cluster Autoscaler</b><br/>Detects empty nodes and deprovisions them"]
     C["<b>Cloud Provider</b><br/>No nodes → no compute charges"]
 
     LO -->|"nodes become idle"| K
@@ -70,7 +70,7 @@ flowchart TD
 
 LightsOut runs two reconcilers in the same operator process.
 
-**`LightsOutScheduleReconciler`** (`internal/controller/lightsoutschedule_controller.go`) — the cluster-scoped reconciler. On each reconciliation cycle it:
+**`LightsOutScheduleReconciler`** (`internal/controller/lightsoutschedule_controller.go`) - the cluster-scoped reconciler. On each reconciliation cycle it:
 
 - Reads the `LightsOutSchedule` spec
 - Delegates to the Period Calculator to determine current state
@@ -83,7 +83,7 @@ LightsOut runs two reconcilers in the same operator process.
 - Updates the schedule's status and conditions
 - Re-queues for the next transition time, or sooner if a batch limit was reached
 
-**`LightsOutNamespaceScheduleReconciler`** (`internal/controller/lightsoutnamespaceschedule_controller.go`) — the namespace-scoped reconciler. It follows the same reconciliation flow but always operates on exactly one namespace: the namespace the `LightsOutNamespaceSchedule` resource lives in. No namespace discovery step is needed.
+**`LightsOutNamespaceScheduleReconciler`** (`internal/controller/lightsoutnamespaceschedule_controller.go`) - the namespace-scoped reconciler. It follows the same reconciliation flow but always operates on exactly one namespace: the namespace the `LightsOutNamespaceSchedule` resource lives in. No namespace discovery step is needed.
 
 A finalizer (`lightsout.techsupport.mk/cleanup`) on both resource types ensures that when a schedule is deleted, all managed workloads are restored to their original state before the resource is removed.
 
@@ -100,9 +100,9 @@ It uses adaptive search windows based on cron frequency to efficiently find the 
 
 Resolves which namespaces are in scope (`internal/controller/namespace.go`). Used only by the cluster-scoped reconciler; the namespace-scoped reconciler always targets its own namespace implicitly. It supports three targeting mechanisms that can be combined:
 
-- **Label selectors** (`namespaceSelector`) — select namespaces by labels
-- **Explicit lists** (`namespaces`) — name specific namespaces
-- **Exclusions** (`excludeNamespaces`) — remove namespaces from the result
+- **Label selectors** (`namespaceSelector`) - select namespaces by labels
+- **Explicit lists** (`namespaces`) - name specific namespaces
+- **Exclusions** (`excludeNamespaces`) - remove namespaces from the result
 
 System namespaces (`kube-system`, `kube-public`, `kube-node-lease`) are always excluded automatically.
 
@@ -112,18 +112,18 @@ After discovery, the global reconciler calls `FilterNamespacesWithLocalSchedules
 
 Handles the actual scaling of Kubernetes workloads (`internal/controller/scaler.go`):
 
-- **Deployments and StatefulSets** — scales replicas to 0 on downscale; restores from the `original-replicas` annotation on upscale
-- **CronJobs** — suspends on downscale; unsuspends on upscale (only if LightsOut was the one that suspended it)
+- **Deployments and StatefulSets** - scales replicas to 0 on downscale; restores from the `original-replicas` annotation on upscale
+- **CronJobs** - suspends on downscale; unsuspends on upscale (only if LightsOut was the one that suspended it)
 
 Key design properties:
 
-- **Idempotent** — safe to retry. If a workload is already scaled down, it won't be touched again.
-- **Respects user intent** — if a user manually scales a workload while it's managed, LightsOut tracks this and won't overwrite user changes.
-- **Managed-by tracking** — each workload is annotated with the schedule name that manages it, preventing conflicts between schedules.
+- **Idempotent** - safe to retry. If a workload is already scaled down, it won't be touched again.
+- **Respects user intent** - if a user manually scales a workload while it's managed, LightsOut tracks this and won't overwrite user changes.
+- **Managed-by tracking** - each workload is annotated with the schedule name that manages it, preventing conflicts between schedules.
 
 ### Rate Limiting
 
-Prevents resource spikes during bulk scaling. When rate limiting is configured (`batchSize` and optional `delayBetweenBatches`), the reconciler uses a **non-blocking budget-based approach**: it processes up to `batchSize` actual scale operations per reconciliation cycle, then returns early and requeues itself after the configured delay. On the next reconcile, it re-lists workloads and continues — already-processed workloads are skipped cheaply via their annotations without consuming budget.
+Prevents resource spikes during bulk scaling. When rate limiting is configured (`batchSize` and optional `delayBetweenBatches`), the reconciler uses a **non-blocking budget-based approach**: it processes up to `batchSize` actual scale operations per reconciliation cycle, then returns early and requeues itself after the configured delay. On the next reconcile, it re-lists workloads and continues - already-processed workloads are skipped cheaply via their annotations without consuming budget.
 
 This design keeps the controller responsive during large-scale operations. Spec changes, suspension, deletion, and period transitions (e.g., an upscale time arriving mid-downscale) are all picked up on the next requeue rather than being blocked until all batches finish. The requeue delay is `min(delayBetweenBatches, timeUntilNextTransition)` to ensure period transitions are never missed.
 
@@ -143,7 +143,7 @@ Execution is ordered to prevent false alerts:
 - **Downscale**: label ArgoCD apps first, then scale workloads
 - **Upscale**: scale workloads first, then transition ArgoCD apps from `down` → `warming-up`, then remove all labels once pods are ready (or `warmupTimeout` elapses)
 
-ArgoCD errors are best-effort — they are logged and emitted as events but never block workload scaling.
+ArgoCD errors are best-effort - they are logged and emitted as events but never block workload scaling.
 
 See the [ArgoCD Integration Guide](argocd.md) for usage details.
 
@@ -153,13 +153,13 @@ See the [ArgoCD Integration Guide](argocd.md) for usage details.
 
 **`LightsOutSchedule`** is cluster-scoped. It is intended for platform teams managing cost policies across multiple namespaces. A single resource can target dozens of namespaces via label selectors.
 
-**`LightsOutNamespaceSchedule`** is namespace-scoped. It allows developers to define their own scaling schedules for their namespace without requiring cluster-level access. When a `LightsOutNamespaceSchedule` exists in a namespace, any `LightsOutSchedule` targeting that namespace will skip it — giving the namespace-scoped schedule full control.
+**`LightsOutNamespaceSchedule`** is namespace-scoped. It allows developers to define their own scaling schedules for their namespace without requiring cluster-level access. When a `LightsOutNamespaceSchedule` exists in a namespace, any `LightsOutSchedule` targeting that namespace will skip it - giving the namespace-scoped schedule full control.
 
 Both types share the same scheduling fields (cron expressions, timezone, workload types, rate limits, ArgoCD integration) via a common `LightsOutScheduleCore` struct. They can be independently enabled via `clusterSchedules.enabled` and `namespaceSchedules.enabled` in Helm values.
 
 #### Upgrade note
 
-The `LightsOutSchedule` reconciler checks for namespace schedules on every reconcile cycle, making one API call per target namespace. For most users this is invisible. If a global schedule targets a very large number of namespaces and reconcile latency matters, set `namespaceSchedules.enabled=false` to skip this check entirely — but this is an edge case, not a default concern.
+The `LightsOutSchedule` reconciler checks for namespace schedules on every reconcile cycle, making one API call per target namespace. For most users this is invisible. If a global schedule targets a very large number of namespaces and reconcile latency matters, set `namespaceSchedules.enabled=false` to skip this check entirely - but this is an edge case, not a default concern.
 
 ### Annotation-Based State
 
@@ -173,7 +173,7 @@ A finalizer on each `LightsOutSchedule` ensures that deleting a schedule restore
 
 Every scaling operation checks current state before acting. This means:
 
-- Partial failures during a reconciliation are safe — the next cycle picks up where it left off
+- Partial failures during a reconciliation are safe - the next cycle picks up where it left off
 - Multiple reconciliations in quick succession don't cause issues
 - The controller can be restarted at any time without data loss
 
@@ -190,9 +190,9 @@ ArgoCD integration uses Kubernetes unstructured objects instead of importing Arg
 
 LightsOut includes optional admission webhooks for validation and defaulting. Both schedule types have their own webhook pair.
 
-**Mutating webhooks** — set `timezone` to `UTC` if not specified.
+**Mutating webhooks** - set `timezone` to `UTC` if not specified.
 
-**Validating webhooks** — reject invalid schedules before they're persisted:
+**Validating webhooks** - reject invalid schedules before they're persisted:
 
 - Validate cron expressions for both `upscale` and `downscale`
 - Validate the timezone is a recognized IANA timezone
@@ -200,7 +200,7 @@ LightsOut includes optional admission webhooks for validation and defaulting. Bo
 - Validate ArgoCD namespace is a valid DNS label when provided
 - Warn (but do not reject) when a schedule may conflict with an existing one
 
-The `LightsOutSchedule` validator additionally requires at least one namespace selection method (`namespaceSelector` or `namespaces`). The `LightsOutNamespaceSchedule` validator omits this check — the owning namespace is always implicit — and instead warns if a global `LightsOutSchedule` already targets the same namespace (explicit or via label selector).
+The `LightsOutSchedule` validator additionally requires at least one namespace selection method (`namespaceSelector` or `namespaces`). The `LightsOutNamespaceSchedule` validator omits this check - the owning namespace is always implicit - and instead warns if a global `LightsOutSchedule` already targets the same namespace (explicit or via label selector).
 
 ## Metrics
 

--- a/docs/argocd.md
+++ b/docs/argocd.md
@@ -88,7 +88,7 @@ This is only needed if Applications are managed declaratively through Git. If yo
 
 ### `RespectIgnoreDifferences` Sync Option
 
-By default, `ignoreDifferences` only suppresses the OutOfSync indicator in the UI — a sync operation will still overwrite LightsOut's changes. To prevent this, each Application must include:
+By default, `ignoreDifferences` only suppresses the OutOfSync indicator in the UI - a sync operation will still overwrite LightsOut's changes. To prevent this, each Application must include:
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -134,7 +134,7 @@ During upscale, the `state` label transitions to `warming-up` and the following 
 |------------|-------|---------|
 | `lightsout.techsupport.mk/warming-up-since` | RFC3339 timestamp | Records when warming-up began; used to enforce `warmupTimeout` across controller restarts |
 
-Once all Deployments and StatefulSets in the target namespace have all their desired replicas ready — or the `warmupTimeout` elapses — both labels and the annotation are removed, leaving the Application CRD pristine.
+Once all Deployments and StatefulSets in the target namespace have all their desired replicas ready - or the `warmupTimeout` elapses - both labels and the annotation are removed, leaving the Application CRD pristine.
 
 ### Execution Ordering
 

--- a/docs/hpa.md
+++ b/docs/hpa.md
@@ -1,0 +1,78 @@
+# HPA Integration
+
+LightsOut automatically handles HorizontalPodAutoscalers (HPAs) attached to Deployments and StatefulSets. When an HPA is present, LightsOut sets `spec.behavior.scaleUp.selectPolicy: Disabled` before scaling the workload down, then restores it after scaling back up. No configuration is required.
+
+## The Problem
+
+When LightsOut scales a Deployment or StatefulSet to zero replicas, an attached HPA with `spec.minReplicas >= 1` will immediately fight back: the HPA controller sees `replicas < minReplicas` and corrects it, silently defeating the off-hours scale-down.
+
+This is a pure Kubernetes control-plane conflict. The reliable fix is to disable the HPA's scale-up behaviour before zeroing the workload, then restore it on upscale.
+
+## How It Works
+
+The feature is automatic and requires no API changes or schedule configuration. LightsOut handles it transparently for any Deployment or StatefulSet that has an attached HPA.
+
+**On downscale:**
+1. LightsOut finds the HPA targeting the workload (by `spec.scaleTargetRef`).
+2. Stores the original `spec.behavior.scaleUp.selectPolicy` value in an annotation on the HPA.
+3. Sets `spec.behavior.scaleUp.selectPolicy: Disabled` to prevent the HPA from fighting back.
+4. Scales the workload's `spec.replicas` to `0`.
+
+Disabling scale-up first prevents the HPA from observing `replicas < minReplicas` even during the brief window between the two API writes. The HPA's `spec.minReplicas` and metric configuration are **not modified**.
+
+**On upscale:**
+1. Restores the workload's `spec.replicas` to the original count.
+2. Restores the HPA's `spec.behavior.scaleUp.selectPolicy` from the stored annotation.
+3. Removes all LightsOut annotations from the HPA.
+
+Restoring replicas first means the HPA sees the workload already at its target count when scale-up is re-enabled — no redundant reconcile is triggered.
+
+## Annotations
+
+LightsOut uses these annotations on the HPA object during the downscale window:
+
+| Annotation | Description |
+|---|---|
+| `lightsout.techsupport.mk/original-hpa-scale-up-policy` | The original `spec.behavior.scaleUp.selectPolicy` value (empty string = field was absent) |
+| `lightsout.techsupport.mk/managed-by` | The schedule name that patched this HPA |
+
+Both annotations are removed when the HPA is restored.
+
+## Skip Conditions
+
+LightsOut will not patch an HPA if any of the following are true:
+
+- **No HPA found** - workloads without an HPA are unaffected; no error is reported.
+- **User-managed disabled scale-up** - if the HPA already has `spec.behavior.scaleUp.selectPolicy: Disabled` and no `managed-by` annotation, LightsOut treats it as intentionally configured and does not claim ownership.
+- **Owned by a different schedule** - multi-schedule safety: only the schedule that patched an HPA can restore it.
+- **Already patched** - if LightsOut previously patched the HPA, repeated reconciles are idempotent.
+
+## Multi-Schedule Safety
+
+LightsOut's multi-schedule safety rules apply to HPAs the same way they apply to workloads:
+
+- An HPA already annotated with `managed-by` pointing to a different schedule is skipped on both patch and restore.
+- Only the owning schedule may restore the HPA.
+
+## RBAC
+
+HPA permissions are always granted. No configuration is required.
+
+| Resource | API Group | Verbs |
+|---|---|---|
+| `horizontalpodautoscalers` | `autoscaling` | get, list, watch, update, patch |
+
+## CronJobs
+
+CronJobs are excluded from HPA handling. Kubernetes does not support HPAs targeting CronJobs (CronJobs do not expose the `scale` subresource), so no HPA logic is applied when suspending or resuming CronJobs.
+
+## Graceful Degradation
+
+- **Cluster without `autoscaling/v2`** - LightsOut detects the missing API and skips HPA handling silently. Workload scaling proceeds normally.
+- **HPA operation fails** - errors are logged at error level but do not block workload scaling. If patching fails on downscale, the workload still scales to zero but the HPA may fight back until the next reconcile corrects it.
+
+## Limitations
+
+- **LightsOut uses `autoscaling/v2` for HPA discovery** - HPAs created via `autoscaling/v1` are served across both API versions by the Kubernetes API server, so they are discovered and patched correctly.
+- **`spec.minReplicas` and metric targets are not modified** - LightsOut only touches `spec.behavior.scaleUp.selectPolicy`. HPA scaling behaviour and minimum replica counts during business hours are unchanged.
+- **If a user-configured `spec.behavior.scaleUp` has other settings** (policies, `stabilizationWindowSeconds`) they are preserved. LightsOut only sets/restores the `selectPolicy` sub-field.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -11,8 +11,9 @@ The LightsOut controller requires **cluster-wide permissions** to modify workloa
 | Deployments | apps | get, list, watch, patch, update | Scale replicas to 0 during off-hours, restore during business hours |
 | StatefulSets | apps | get, list, watch, patch, update | Scale replicas to 0 during off-hours, restore during business hours |
 | CronJobs | batch | get, list, watch, patch, update | Suspend/unsuspend scheduled jobs |
+| HorizontalPodAutoscalers | autoscaling | get, list, watch, update, patch | Disable scale-up during downscale to prevent fight-back, restore on upscale |
 | Namespaces | core | get, list, watch | Discover namespaces for namespace selectors |
-| Events | core | create, patch | Record scaling events for observability |
+| Events | core, events.k8s.io | create, patch | Record scaling events for observability (controller-runtime uses the `events.k8s.io` API group on modern clusters) |
 | LightsOutSchedules | lightsout.techsupport.mk | get, list, watch, create, update, patch, delete | Manage cluster-scoped schedules |
 | LightsOutNamespaceSchedules | lightsout.techsupport.mk | get, list, watch, create, update, patch, delete | Manage namespace-scoped schedules; global controller lists these to implement precedence |
 | Applications | argoproj.io | get, list, watch, update, patch | Label ArgoCD Application CRDs during scaling (optional) |

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -2,8 +2,8 @@
 
 This guide covers two installation paths:
 
-1. **Basic** — controller only, no webhooks
-2. **With webhooks and cert-manager** — adds validation, defaulting, and overlap detection
+1. **Basic** - controller only, no webhooks
+2. **With webhooks and cert-manager** - adds validation, defaulting, and overlap detection
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ This guide covers two installation paths:
 
 ## Basic Install
 
-This installs the LightsOut controller without admission webhooks. Schedules will not be validated on creation — the controller will still work, but invalid cron expressions or misconfigurations won't be caught until reconciliation.
+This installs the LightsOut controller without admission webhooks. Schedules will not be validated on creation - the controller will still work, but invalid cron expressions or misconfigurations won't be caught until reconciliation.
 
 ### 1. Install
 

--- a/examples/localdemo/demo.sh
+++ b/examples/localdemo/demo.sh
@@ -73,6 +73,15 @@ cmd_up() {
         --namespace cert-manager \
         --timeout=120s
 
+    # Install metrics-server (Kind requires --kubelet-insecure-tls due to self-signed certs)
+    log "Installing metrics-server..."
+    helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/ 2>/dev/null || true
+    helm repo update metrics-server
+    helm upgrade --install metrics-server metrics-server/metrics-server \
+        --namespace kube-system \
+        --set args={--kubelet-insecure-tls} \
+        --wait --timeout 2m
+
     # Install kube-prometheus-stack
     log "Installing kube-prometheus-stack..."
     helm repo add prometheus-community https://prometheus-community.github.io/helm-charts 2>/dev/null || true

--- a/examples/localdemo/manifests/apps-backend.yaml
+++ b/examples/localdemo/manifests/apps-backend.yaml
@@ -100,3 +100,43 @@ spec:
                   cpu: 50m
                   memory: 16Mi
           restartPolicy: OnFailure
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-server
+  namespace: team-backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api-server
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: worker
+  namespace: team-backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: worker
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/hack/check-helm-rbac.py
+++ b/hack/check-helm-rbac.py
@@ -1,4 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["pyyaml"]
+# ///
 """
 Verify that the Helm chart ClusterRole rules
 (charts/lightsout/templates/clusterrole.yaml) are in sync with the

--- a/internal/constants/annotations.go
+++ b/internal/constants/annotations.go
@@ -14,6 +14,11 @@ const (
 	// OriginalSuspendAnnotation stores who suspended the CronJob ("lightsout" or "user")
 	OriginalSuspendAnnotation = AnnotationPrefix + "original-suspend"
 
+	// OriginalHPAScaleUpPolicyAnnotation stores the HPA's original
+	// spec.behavior.scaleUp.selectPolicy value before LightsOut sets it to "Disabled"
+	// during downscale. Empty string means the field was absent (default behaviour).
+	OriginalHPAScaleUpPolicyAnnotation = AnnotationPrefix + "original-hpa-scale-up-policy"
+
 	// ManagedByAnnotation stores the name of the Schedule managing this workload
 	ManagedByAnnotation = AnnotationPrefix + "managed-by"
 

--- a/internal/controller/batcher.go
+++ b/internal/controller/batcher.go
@@ -6,6 +6,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -280,7 +281,7 @@ func collectNamespaceCronJobs(ctx context.Context, c client.Client, ns string, c
 // the controller framework.
 //
 // Skipped workloads (already at target state) do not consume budget, making re-entry
-// after requeue cheap — the reconciler naturally picks up where it left off via
+// after requeue cheap - the reconciler naturally picks up where it left off via
 // annotation-based idempotency.
 func scaleWorkloads(
 	ctx context.Context,
@@ -294,6 +295,20 @@ func scaleWorkloads(
 	workloads, err := collectWorkloads(ctx, c, cfg.Namespaces, core, cfg.ScheduleName, cfg.TransferOwnership)
 	if err != nil {
 		return nil, err
+	}
+
+	// Pre-fetch HPA lists once per namespace so every ScaleDeployment/ScaleStatefulSet call in
+	// the loop below reuses the same in-memory snapshot instead of issuing a separate List call
+	// per workload (O(1) API calls per namespace instead of O(workloads)).
+	hpaLists := make(map[string]*unstructured.UnstructuredList, len(cfg.Namespaces))
+	for _, ns := range cfg.Namespaces {
+		list, hpaErr := listHPAs(ctx, c, ns)
+		if hpaErr != nil {
+			logger.Error(hpaErr, "failed to list HPAs, HPA integration disabled for namespace", "namespace", ns)
+			// nil entry - PatchHPAForDownscale/RestoreHPA gracefully no-op for this namespace
+		} else {
+			hpaLists[ns] = list
+		}
 	}
 
 	// Determine budget: unlimited (-1) if no rate limit, otherwise batchSize
@@ -330,9 +345,9 @@ func scaleWorkloads(
 
 		switch w.Type {
 		case WorkloadTypeDeployment:
-			scaleResult, scaleErr = ScaleDeployment(ctx, c, w.Deployment, cfg.ScheduleName, cfg.ScaleUp)
+			scaleResult, scaleErr = ScaleDeployment(ctx, c, w.Deployment, cfg.ScheduleName, cfg.ScaleUp, hpaLists[w.Namespace])
 		case WorkloadTypeStatefulSet:
-			scaleResult, scaleErr = ScaleStatefulSet(ctx, c, w.StatefulSet, cfg.ScheduleName, cfg.ScaleUp)
+			scaleResult, scaleErr = ScaleStatefulSet(ctx, c, w.StatefulSet, cfg.ScheduleName, cfg.ScaleUp, hpaLists[w.Namespace])
 		case WorkloadTypeCronJob:
 			scaleResult, scaleErr = ScaleCronJob(ctx, c, w.CronJob, cfg.ScheduleName, cfg.ScaleUp)
 		}
@@ -382,7 +397,7 @@ func scaleWorkloads(
 		}
 	}
 
-	// All workloads processed — record metrics
+	// All workloads processed - record metrics
 	ScalingDurationSeconds.WithLabelValues(cfg.ScheduleLabel, direction).Observe(time.Since(startTime).Seconds())
 	if totalProcessed > 0 {
 		ScalingBatchesTotal.WithLabelValues(cfg.ScheduleLabel, direction).Inc()

--- a/internal/controller/hpa.go
+++ b/internal/controller/hpa.go
@@ -1,0 +1,199 @@
+package controller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/gjorgji-ts/lightsout/internal/constants"
+)
+
+// hpaScaleUpDisabled is the selectPolicy value that disables HPA scale-up.
+const hpaScaleUpDisabled = "Disabled"
+
+var hpaGVK = schema.GroupVersionKind{
+	Group:   "autoscaling",
+	Version: "v2",
+	Kind:    "HorizontalPodAutoscaler",
+}
+
+// hpaWatchObject returns an unstructured HPA object suitable for passing to
+// controller-runtime's Watches() to register an informer for autoscaling/v2 HPAs.
+func hpaWatchObject() *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(hpaGVK)
+	return obj
+}
+
+// listHPAs fetches all HPAs in namespace using the autoscaling/v2 API.
+// The HPA informer must be registered (via Watches in SetupWithManager) before
+// calling this, so the cache-backed client can serve the List request.
+// Returns (nil, nil) if the API is not available on the cluster.
+func listHPAs(ctx context.Context, c client.Client, namespace string) (*unstructured.UnstructuredList, error) {
+	logger := log.FromContext(ctx)
+
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   hpaGVK.Group,
+		Version: hpaGVK.Version,
+		Kind:    hpaGVK.Kind + "List",
+	})
+
+	if err := c.List(ctx, list, client.InNamespace(namespace)); err != nil {
+		if meta.IsNoMatchError(err) {
+			logger.V(1).Info("autoscaling/v2 HPA not available on cluster, skipping HPA integration")
+			return nil, nil
+		}
+		return nil, err
+	}
+	// The Kubernetes API server does not include apiVersion/kind in list items, so each
+	// Unstructured item has an empty GVK. Stamp it explicitly so c.Patch can resolve the
+	// correct REST endpoint when called later.
+	for i := range list.Items {
+		list.Items[i].SetGroupVersionKind(hpaGVK)
+	}
+	return list, nil
+}
+
+// findHPA scans a pre-fetched HPA list and returns the entry targeting the given workload
+// kind/name. Returns nil if the list is nil or no matching HPA exists.
+func findHPA(list *unstructured.UnstructuredList, kind, name string) *unstructured.Unstructured {
+	if list == nil {
+		return nil
+	}
+	for i := range list.Items {
+		hpa := &list.Items[i]
+		targetKind, _, _ := unstructured.NestedString(hpa.Object, "spec", "scaleTargetRef", "kind")
+		targetName, _, _ := unstructured.NestedString(hpa.Object, "spec", "scaleTargetRef", "name")
+		if targetKind == kind && targetName == name {
+			return hpa
+		}
+	}
+	return nil
+}
+
+// PatchHPAForDownscale finds the HPA targeting the given workload in hpaList, stores the
+// original spec.behavior.scaleUp.selectPolicy as an annotation, stamps managed-by, and
+// sets spec.behavior.scaleUp.selectPolicy=Disabled to prevent the HPA from fighting back
+// when the deployment is scaled to 0.
+// hpaList must be fetched with listHPAs before calling, pass nil to skip HPA handling.
+// Call this before the workload's replica write on downscale.
+// Errors are returned to the caller, the caller treats them as non-fatal.
+func PatchHPAForDownscale(ctx context.Context, c client.Client, hpaList *unstructured.UnstructuredList, namespace, kind, name, scheduleName string) error {
+	logger := log.FromContext(ctx).WithValues("hpa.namespace", namespace, "hpa.targetKind", kind, "hpa.targetName", name)
+
+	hpa := findHPA(hpaList, kind, name)
+	if hpa == nil {
+		return nil
+	}
+
+	orig := hpa.DeepCopy()
+
+	annotations := hpa.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	managedBy := annotations[constants.ManagedByAnnotation]
+
+	// Skip if owned by a different schedule
+	if managedBy != "" && managedBy != scheduleName {
+		logger.V(1).Info("skipping HPA: managed by different schedule", "managedBy", managedBy)
+		return nil
+	}
+
+	// Idempotent: already patched by this schedule
+	if managedBy == scheduleName {
+		logger.V(1).Info("skipping HPA: already patched by this schedule")
+		return nil
+	}
+
+	// Read current selectPolicy; if it's already Disabled and there's no managed-by
+	// annotation, this is a user-managed HPA - skip it.
+	currentPolicy, _, _ := unstructured.NestedString(hpa.Object, "spec", "behavior", "scaleUp", "selectPolicy")
+	if currentPolicy == hpaScaleUpDisabled {
+		logger.V(1).Info("skipping HPA: user-managed scale-up already disabled")
+		return nil
+	}
+
+	// Store original policy value (empty string = field was absent, i.e. default behaviour)
+	annotations[constants.OriginalHPAScaleUpPolicyAnnotation] = currentPolicy
+	annotations[constants.ManagedByAnnotation] = scheduleName
+	hpa.SetAnnotations(annotations)
+
+	if err := unstructured.SetNestedField(hpa.Object, hpaScaleUpDisabled, "spec", "behavior", "scaleUp", "selectPolicy"); err != nil {
+		return err
+	}
+
+	if err := c.Patch(ctx, hpa, client.MergeFrom(orig)); err != nil {
+		return err
+	}
+
+	logger.Info("disabled HPA scaleUp to prevent fight-back during downscale", "originalSelectPolicy", currentPolicy)
+	return nil
+}
+
+// RestoreHPA finds the HPA targeting the given workload in hpaList, reads the original
+// spec.behavior.scaleUp.selectPolicy from the annotation, restores it, and removes all
+// lightsout annotations.
+// hpaList must be fetched with listHPAs before calling, pass nil to skip HPA handling.
+// Call this after the replica write succeeds on upscale.
+// Errors are returned to the caller, the caller treats them as non-fatal.
+func RestoreHPA(ctx context.Context, c client.Client, hpaList *unstructured.UnstructuredList, namespace, kind, name, scheduleName string) error {
+	logger := log.FromContext(ctx).WithValues("hpa.namespace", namespace, "hpa.targetKind", kind, "hpa.targetName", name)
+
+	hpa := findHPA(hpaList, kind, name)
+	if hpa == nil {
+		return nil
+	}
+
+	orig := hpa.DeepCopy()
+
+	annotations := hpa.GetAnnotations()
+	if annotations == nil {
+		return nil
+	}
+
+	managedBy := annotations[constants.ManagedByAnnotation]
+
+	// Not managed by LightsOut
+	if managedBy == "" {
+		return nil
+	}
+
+	// Managed by a different schedule
+	if managedBy != scheduleName {
+		logger.V(1).Info("skipping HPA restore: managed by different schedule", "managedBy", managedBy)
+		return nil
+	}
+
+	origPolicy, hasPolicyAnnotation := annotations[constants.OriginalHPAScaleUpPolicyAnnotation]
+	if !hasPolicyAnnotation {
+		logger.Info("HPA managed-by annotation present but original-hpa-scale-up-policy absent; skipping restore")
+		return nil
+	}
+
+	if origPolicy == "" {
+		// Field was absent originally - remove selectPolicy so the HPA returns to default
+		unstructured.RemoveNestedField(hpa.Object, "spec", "behavior", "scaleUp", "selectPolicy")
+	} else {
+		if err := unstructured.SetNestedField(hpa.Object, origPolicy, "spec", "behavior", "scaleUp", "selectPolicy"); err != nil {
+			return err
+		}
+	}
+
+	delete(annotations, constants.OriginalHPAScaleUpPolicyAnnotation)
+	delete(annotations, constants.ManagedByAnnotation)
+	hpa.SetAnnotations(annotations)
+
+	if err := c.Patch(ctx, hpa, client.MergeFrom(orig)); err != nil {
+		return err
+	}
+
+	logger.Info("restored HPA scaleUp policy", "restoredTo", origPolicy)
+	return nil
+}

--- a/internal/controller/hpa_test.go
+++ b/internal/controller/hpa_test.go
@@ -1,0 +1,284 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/gjorgji-ts/lightsout/internal/constants"
+)
+
+// mustListHPAs is a test helper that calls listHPAs and fails the test on error.
+func mustListHPAs(t *testing.T, c client.Client) *unstructured.UnstructuredList {
+	t.Helper()
+	list, err := listHPAs(context.Background(), c, "ns")
+	if err != nil {
+		t.Fatalf("listHPAs: %v", err)
+	}
+	return list
+}
+
+func TestPatchHPAForDownscale_HPAFound(t *testing.T) {
+	hpa := makeHPA("Deployment", "my-deploy", nil, nil)
+	fakeClient := fake.NewClientBuilder().WithScheme(hpaScheme()).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	err := PatchHPAForDownscale(context.Background(), fakeClient, hpaList, "ns", "Deployment", "my-deploy", testScheduleName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	if err := fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updated); err != nil {
+		t.Fatalf("failed to get updated HPA: %v", err)
+	}
+
+	policy, _, _ := unstructured.NestedString(updated.Object, "spec", "behavior", "scaleUp", "selectPolicy")
+	if policy != hpaScaleUpDisabled {
+		t.Errorf("expected scaleUp.selectPolicy=Disabled, got %q", policy)
+	}
+	annotations := updated.GetAnnotations()
+	if annotations[constants.OriginalHPAScaleUpPolicyAnnotation] != "" {
+		t.Errorf("expected original-hpa-scale-up-policy='' (absent), got %q", annotations[constants.OriginalHPAScaleUpPolicyAnnotation])
+	}
+	if annotations[constants.ManagedByAnnotation] != testScheduleName {
+		t.Errorf("expected managed-by=my-schedule, got %q", annotations[constants.ManagedByAnnotation])
+	}
+}
+
+func TestPatchHPAForDownscale_NoHPA(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(hpaScheme()).Build()
+	hpaList := mustListHPAs(t, fakeClient)
+	err := PatchHPAForDownscale(context.Background(), fakeClient, hpaList, "ns", "Deployment", "my-deploy", testScheduleName)
+	if err != nil {
+		t.Fatalf("expected no error when no HPA found, got: %v", err)
+	}
+}
+
+func TestPatchHPAForDownscale_UserManagedDisabled(t *testing.T) {
+	// User has already disabled scale-up - LightsOut should not touch this HPA
+	hpa := makeHPA("Deployment", "my-deploy", nil, nil)
+	_ = unstructured.SetNestedField(hpa.Object, hpaScaleUpDisabled, "spec", "behavior", "scaleUp", "selectPolicy")
+	fakeClient := fake.NewClientBuilder().WithScheme(hpaScheme()).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	err := PatchHPAForDownscale(context.Background(), fakeClient, hpaList, "ns", "Deployment", "my-deploy", testScheduleName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updated)
+	if updated.GetAnnotations()[constants.ManagedByAnnotation] != "" {
+		t.Error("expected HPA to be skipped (no managed-by stamped)")
+	}
+}
+
+func TestPatchHPAForDownscale_DifferentSchedule(t *testing.T) {
+	hpa := makeHPA("Deployment", "my-deploy", nil, map[string]string{
+		constants.ManagedByAnnotation:                "other-schedule",
+		constants.OriginalHPAScaleUpPolicyAnnotation: "",
+	})
+	_ = unstructured.SetNestedField(hpa.Object, hpaScaleUpDisabled, "spec", "behavior", "scaleUp", "selectPolicy")
+	fakeClient := fake.NewClientBuilder().WithScheme(hpaScheme()).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	err := PatchHPAForDownscale(context.Background(), fakeClient, hpaList, "ns", "Deployment", "my-deploy", testScheduleName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updated)
+	if updated.GetAnnotations()[constants.ManagedByAnnotation] != "other-schedule" {
+		t.Error("expected HPA ownership to remain with other-schedule")
+	}
+}
+
+func TestPatchHPAForDownscale_AlreadyPatched(t *testing.T) {
+	hpa := makeHPA("Deployment", "my-deploy", nil, map[string]string{
+		constants.ManagedByAnnotation:                testScheduleName,
+		constants.OriginalHPAScaleUpPolicyAnnotation: "",
+	})
+	_ = unstructured.SetNestedField(hpa.Object, hpaScaleUpDisabled, "spec", "behavior", "scaleUp", "selectPolicy")
+	fakeClient := fake.NewClientBuilder().WithScheme(hpaScheme()).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	err := PatchHPAForDownscale(context.Background(), fakeClient, hpaList, "ns", "Deployment", "my-deploy", testScheduleName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Second call should be idempotent - managed-by stays, no double-patch
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updated)
+	if updated.GetAnnotations()[constants.ManagedByAnnotation] != testScheduleName {
+		t.Errorf("expected managed-by to remain my-schedule")
+	}
+}
+
+func TestPatchHPAForDownscale_PreservesExistingPolicy(t *testing.T) {
+	// HPA had "Min" selectPolicy set by user - we should store it and set Disabled
+	hpa := makeHPA("Deployment", "my-deploy", nil, nil)
+	_ = unstructured.SetNestedField(hpa.Object, "Min", "spec", "behavior", "scaleUp", "selectPolicy")
+	fakeClient := fake.NewClientBuilder().WithScheme(hpaScheme()).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	err := PatchHPAForDownscale(context.Background(), fakeClient, hpaList, "ns", "Deployment", "my-deploy", testScheduleName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updated)
+
+	policy, _, _ := unstructured.NestedString(updated.Object, "spec", "behavior", "scaleUp", "selectPolicy")
+	if policy != hpaScaleUpDisabled {
+		t.Errorf("expected scaleUp.selectPolicy=Disabled, got %q", policy)
+	}
+	if updated.GetAnnotations()[constants.OriginalHPAScaleUpPolicyAnnotation] != "Min" {
+		t.Errorf("expected original-hpa-scale-up-policy=Min, got %q", updated.GetAnnotations()[constants.OriginalHPAScaleUpPolicyAnnotation])
+	}
+}
+
+func TestRestoreHPA_Success(t *testing.T) {
+	hpa := makeHPA("Deployment", "my-deploy", nil, map[string]string{
+		constants.ManagedByAnnotation:                testScheduleName,
+		constants.OriginalHPAScaleUpPolicyAnnotation: "",
+	})
+	_ = unstructured.SetNestedField(hpa.Object, hpaScaleUpDisabled, "spec", "behavior", "scaleUp", "selectPolicy")
+	fakeClient := fake.NewClientBuilder().WithScheme(hpaScheme()).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	err := RestoreHPA(context.Background(), fakeClient, hpaList, "ns", "Deployment", "my-deploy", testScheduleName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updated)
+
+	// selectPolicy should be absent (restored to default)
+	policy, found, _ := unstructured.NestedString(updated.Object, "spec", "behavior", "scaleUp", "selectPolicy")
+	if found && policy != "" {
+		t.Errorf("expected selectPolicy to be removed, got %q", policy)
+	}
+	annotations := updated.GetAnnotations()
+	if annotations[constants.OriginalHPAScaleUpPolicyAnnotation] != "" {
+		t.Error("expected original-hpa-scale-up-policy annotation to be removed")
+	}
+	if annotations[constants.ManagedByAnnotation] != "" {
+		t.Error("expected managed-by annotation to be removed")
+	}
+}
+
+func TestRestoreHPA_NoHPA(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(hpaScheme()).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	err := RestoreHPA(context.Background(), fakeClient, hpaList, "ns", "Deployment", "my-deploy", testScheduleName)
+	if err != nil {
+		t.Fatalf("expected no error when no HPA found, got: %v", err)
+	}
+}
+
+func TestRestoreHPA_NoManagedByAnnotation(t *testing.T) {
+	hpa := makeHPA("Deployment", "my-deploy", nil, nil)
+	fakeClient := fake.NewClientBuilder().WithScheme(hpaScheme()).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	err := RestoreHPA(context.Background(), fakeClient, hpaList, "ns", "Deployment", "my-deploy", testScheduleName)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updated)
+	// selectPolicy should be unchanged (absent)
+	_, found, _ := unstructured.NestedString(updated.Object, "spec", "behavior", "scaleUp", "selectPolicy")
+	if found {
+		t.Error("expected selectPolicy to remain absent")
+	}
+}
+
+func TestRestoreHPA_DifferentSchedule(t *testing.T) {
+	hpa := makeHPA("Deployment", "my-deploy", nil, map[string]string{
+		constants.ManagedByAnnotation:                "other-schedule",
+		constants.OriginalHPAScaleUpPolicyAnnotation: "",
+	})
+	_ = unstructured.SetNestedField(hpa.Object, hpaScaleUpDisabled, "spec", "behavior", "scaleUp", "selectPolicy")
+	fakeClient := fake.NewClientBuilder().WithScheme(hpaScheme()).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	err := RestoreHPA(context.Background(), fakeClient, hpaList, "ns", "Deployment", "my-deploy", testScheduleName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updated)
+	if updated.GetAnnotations()[constants.ManagedByAnnotation] != "other-schedule" {
+		t.Error("expected ownership to remain with other-schedule")
+	}
+}
+
+func TestRestoreHPA_MissingPolicyAnnotation(t *testing.T) {
+	hpa := makeHPA("Deployment", "my-deploy", nil, map[string]string{
+		constants.ManagedByAnnotation: testScheduleName,
+	})
+	_ = unstructured.SetNestedField(hpa.Object, hpaScaleUpDisabled, "spec", "behavior", "scaleUp", "selectPolicy")
+	fakeClient := fake.NewClientBuilder().WithScheme(hpaScheme()).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	err := RestoreHPA(context.Background(), fakeClient, hpaList, "ns", "Deployment", "my-deploy", testScheduleName)
+	if err != nil {
+		t.Fatalf("expected no error (warning only), got: %v", err)
+	}
+
+	// selectPolicy should remain unchanged (no restore attempted)
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updated)
+	policy, _, _ := unstructured.NestedString(updated.Object, "spec", "behavior", "scaleUp", "selectPolicy")
+	if policy != hpaScaleUpDisabled {
+		t.Errorf("expected selectPolicy unchanged at Disabled when annotation absent, got %q", policy)
+	}
+}
+
+func TestRestoreHPA_RestoresNonEmptyPolicy(t *testing.T) {
+	// Original policy was "Min" - should be restored
+	hpa := makeHPA("Deployment", "my-deploy", nil, map[string]string{
+		constants.ManagedByAnnotation:                testScheduleName,
+		constants.OriginalHPAScaleUpPolicyAnnotation: "Min",
+	})
+	_ = unstructured.SetNestedField(hpa.Object, hpaScaleUpDisabled, "spec", "behavior", "scaleUp", "selectPolicy")
+	fakeClient := fake.NewClientBuilder().WithScheme(hpaScheme()).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	err := RestoreHPA(context.Background(), fakeClient, hpaList, "ns", "Deployment", "my-deploy", testScheduleName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updated)
+	policy, _, _ := unstructured.NestedString(updated.Object, "spec", "behavior", "scaleUp", "selectPolicy")
+	if policy != "Min" {
+		t.Errorf("expected selectPolicy=Min after restore, got %q", policy)
+	}
+	if updated.GetAnnotations()[constants.OriginalHPAScaleUpPolicyAnnotation] != "" {
+		t.Error("expected original-hpa-scale-up-policy annotation to be removed")
+	}
+}

--- a/internal/controller/lightsoutnamespaceschedule_controller.go
+++ b/internal/controller/lightsoutnamespaceschedule_controller.go
@@ -32,8 +32,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	lightsoutv1alpha1 "github.com/gjorgji-ts/lightsout/api/v1alpha1"
 	"github.com/gjorgji-ts/lightsout/internal/constants"
@@ -55,7 +57,9 @@ type LightsOutNamespaceScheduleReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=argoproj.io,resources=applications,verbs=get;list;watch;update;patch
 
 func (r *LightsOutNamespaceScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -190,7 +194,7 @@ func (r *LightsOutNamespaceScheduleReconciler) Reconcile(ctx context.Context, re
 	// Record events for scaling operations
 	recordScalingEvents(r.Recorder, &schedule, scaleUp, stats, namespaces)
 
-	// Record metrics — use "namespace/name" as label to distinguish from global schedules
+	// Record metrics - use "namespace/name" as label to distinguish from global schedules
 	scheduleLabel := schedule.Namespace + "/" + schedule.Name
 	stateValue := float64(0)
 	if stillWarmingUp {
@@ -258,13 +262,18 @@ func (r *LightsOutNamespaceScheduleReconciler) handleDeletion(ctx context.Contex
 	var restoreErrors []string
 	ns := schedule.Namespace
 
+	hpaList, hpaErr := listHPAs(ctx, r.Client, ns)
+	if hpaErr != nil {
+		logger.Error(hpaErr, "failed to list HPAs during deletion, HPA restore skipped", "namespace", ns)
+	}
+
 	// Restore Deployments
 	deployments, err := listManagedDeployments(ctx, r.Client, ns, schedule.Name)
 	if err != nil {
 		restoreErrors = append(restoreErrors, fmt.Sprintf("list deployments in %s: %v", ns, err))
 	} else {
 		for i := range deployments {
-			result, err := ScaleDeployment(ctx, r.Client, &deployments[i], schedule.Name, true)
+			result, err := ScaleDeployment(ctx, r.Client, &deployments[i], schedule.Name, true, hpaList)
 			if err != nil {
 				restoreErrors = append(restoreErrors, fmt.Sprintf("deployment %s/%s: %v", ns, deployments[i].Name, err))
 			} else {
@@ -279,7 +288,7 @@ func (r *LightsOutNamespaceScheduleReconciler) handleDeletion(ctx context.Contex
 		restoreErrors = append(restoreErrors, fmt.Sprintf("list statefulsets in %s: %v", ns, err))
 	} else {
 		for i := range statefulsets {
-			result, err := ScaleStatefulSet(ctx, r.Client, &statefulsets[i], schedule.Name, true)
+			result, err := ScaleStatefulSet(ctx, r.Client, &statefulsets[i], schedule.Name, true, hpaList)
 			if err != nil {
 				restoreErrors = append(restoreErrors, fmt.Sprintf("statefulset %s/%s: %v", ns, statefulsets[i].Name, err))
 			} else {
@@ -351,6 +360,11 @@ func (r *LightsOutNamespaceScheduleReconciler) SetupWithManager(mgr ctrl.Manager
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&lightsoutv1alpha1.LightsOutNamespaceSchedule{},
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		// Watch HPAs to populate the informer cache so c.List works during reconciliation.
+		// HPA changes do not trigger schedule reconciles (no-op handler).
+		Watches(hpaWatchObject(), handler.EnqueueRequestsFromMapFunc(
+			func(_ context.Context, _ client.Object) []reconcile.Request { return nil },
+		)).
 		Named("lightsoutnamespaceschedule").
 		Complete(r)
 }

--- a/internal/controller/lightsoutschedule_controller.go
+++ b/internal/controller/lightsoutschedule_controller.go
@@ -33,8 +33,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	lightsoutv1alpha1 "github.com/gjorgji-ts/lightsout/api/v1alpha1"
 	"github.com/gjorgji-ts/lightsout/internal/constants"
@@ -57,7 +59,9 @@ type LightsOutScheduleReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=argoproj.io,resources=applications,verbs=get;list;watch;update;patch
 
 func (r *LightsOutScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -126,7 +130,7 @@ func (r *LightsOutScheduleReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 
-	// Filter out namespaces that have a LightsOutNamespaceSchedule —
+	// Filter out namespaces that have a LightsOutNamespaceSchedule -
 	// namespace-scoped schedules take precedence over this global schedule.
 	namespaces, err = FilterNamespacesWithLocalSchedules(ctx, r.Client, namespaces)
 	if err != nil {
@@ -282,7 +286,7 @@ func (r *LightsOutScheduleReconciler) handleDeletion(ctx context.Context, schedu
 		// Continue with cleanup even if namespace discovery fails
 	}
 
-	// Filter out namespaces that have a LightsOutNamespaceSchedule —
+	// Filter out namespaces that have a LightsOutNamespaceSchedule -
 	// namespace-scoped schedules manage their own cleanup on deletion.
 	namespaces, err = FilterNamespacesWithLocalSchedules(ctx, r.Client, namespaces)
 	if err != nil {
@@ -292,12 +296,17 @@ func (r *LightsOutScheduleReconciler) handleDeletion(ctx context.Context, schedu
 
 	// Restore workloads in each namespace
 	for _, ns := range namespaces {
+		hpaList, hpaErr := listHPAs(ctx, r.Client, ns)
+		if hpaErr != nil {
+			logger.Error(hpaErr, "failed to list HPAs during deletion, HPA restore skipped", "namespace", ns)
+		}
+
 		deployments, err := listManagedDeployments(ctx, r.Client, ns, schedule.Name)
 		if err != nil {
 			restoreErrors = append(restoreErrors, fmt.Sprintf("list deployments in %s: %v", ns, err))
 		} else {
 			for i := range deployments {
-				result, err := ScaleDeployment(ctx, r.Client, &deployments[i], schedule.Name, true)
+				result, err := ScaleDeployment(ctx, r.Client, &deployments[i], schedule.Name, true, hpaList)
 				if err != nil {
 					restoreErrors = append(restoreErrors, fmt.Sprintf("deployment %s/%s: %v", ns, deployments[i].Name, err))
 				} else {
@@ -311,7 +320,7 @@ func (r *LightsOutScheduleReconciler) handleDeletion(ctx context.Context, schedu
 			restoreErrors = append(restoreErrors, fmt.Sprintf("list statefulsets in %s: %v", ns, err))
 		} else {
 			for i := range statefulsets {
-				result, err := ScaleStatefulSet(ctx, r.Client, &statefulsets[i], schedule.Name, true)
+				result, err := ScaleStatefulSet(ctx, r.Client, &statefulsets[i], schedule.Name, true, hpaList)
 				if err != nil {
 					restoreErrors = append(restoreErrors, fmt.Sprintf("statefulset %s/%s: %v", ns, statefulsets[i].Name, err))
 				} else {
@@ -388,7 +397,7 @@ func calculateRequeueAfter(period *PeriodResult, scaleUp bool, scaleResult *scal
 	}
 
 	if scaleResult.batchLimitReached {
-		// More workloads to process — requeue after batch delay, but not later
+		// More workloads to process - requeue after batch delay, but not later
 		// than the next period transition (so we don't miss direction changes).
 		requeueAfter := timeUntilNext
 		if rateLimit != nil && rateLimit.DelayBetweenBatches != nil {
@@ -399,11 +408,11 @@ func calculateRequeueAfter(period *PeriodResult, scaleUp bool, scaleResult *scal
 		return max(requeueAfter, time.Second)
 	}
 	if stillWarmingUp {
-		// ArgoCD apps are warming up — poll readiness at WarmupCheckInterval,
+		// ArgoCD apps are warming up - poll readiness at WarmupCheckInterval,
 		// but no later than the next period transition.
 		return max(min(constants.WarmupCheckInterval, timeUntilNext), time.Second)
 	}
-	// Defensive floor for the idle path — next transition is typically hours away.
+	// Defensive floor for the idle path - next transition is typically hours away.
 	return max(timeUntilNext, time.Minute)
 }
 
@@ -420,6 +429,11 @@ func (r *LightsOutScheduleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&lightsoutv1alpha1.LightsOutSchedule{},
 			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		// Watch HPAs to populate the informer cache so c.List works during reconciliation.
+		// HPA changes do not trigger schedule reconciles (no-op handler).
+		Watches(hpaWatchObject(), handler.EnqueueRequestsFromMapFunc(
+			func(_ context.Context, _ client.Object) []reconcile.Request { return nil },
+		)).
 		Named("lightsoutschedule").
 		Complete(r)
 }

--- a/internal/controller/scaler.go
+++ b/internal/controller/scaler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -23,9 +24,10 @@ type ScaleResult struct {
 	NewValue      string
 }
 
-// ScaleDeployment scales a deployment up or down based on the period
-// scaleUp=true means restore to original replicas, scaleUp=false means scale to 0
-func ScaleDeployment(ctx context.Context, c client.Client, deploy *appsv1.Deployment, scheduleName string, scaleUp bool) (*ScaleResult, error) {
+// ScaleDeployment scales a deployment up or down based on the period.
+// scaleUp=true means restore to original replicas, scaleUp=false means scale to 0.
+// hpaList is the pre-fetched HPA list for the deployment's namespace; pass nil to skip HPA handling.
+func ScaleDeployment(ctx context.Context, c client.Client, deploy *appsv1.Deployment, scheduleName string, scaleUp bool, hpaList *unstructured.UnstructuredList) (*ScaleResult, error) {
 	logger := log.FromContext(ctx).WithValues("deployment", deploy.Name, "namespace", deploy.Namespace)
 
 	if deploy.Annotations == nil {
@@ -36,12 +38,12 @@ func ScaleDeployment(ctx context.Context, c client.Client, deploy *appsv1.Deploy
 	originalReplicas := deploy.Annotations[constants.OriginalReplicasAnnotation]
 
 	if scaleUp {
-		return scaleDeploymentUp(ctx, c, deploy, scheduleName, managedBy, originalReplicas, logger)
+		return scaleDeploymentUp(ctx, c, deploy, scheduleName, managedBy, originalReplicas, hpaList, logger)
 	}
-	return scaleDeploymentDown(ctx, c, deploy, scheduleName, managedBy, originalReplicas, logger)
+	return scaleDeploymentDown(ctx, c, deploy, scheduleName, managedBy, originalReplicas, hpaList, logger)
 }
 
-func scaleDeploymentDown(ctx context.Context, c client.Client, deploy *appsv1.Deployment, scheduleName, managedBy, originalReplicas string, logger logr.Logger) (*ScaleResult, error) {
+func scaleDeploymentDown(ctx context.Context, c client.Client, deploy *appsv1.Deployment, scheduleName, managedBy, originalReplicas string, hpaList *unstructured.UnstructuredList, logger logr.Logger) (*ScaleResult, error) {
 	// Skip if managed by different schedule
 	if managedBy != "" && managedBy != scheduleName {
 		logger.Info("skipping deployment: managed by different schedule", "managedBy", managedBy)
@@ -68,6 +70,12 @@ func scaleDeploymentDown(ctx context.Context, c client.Client, deploy *appsv1.De
 		return &ScaleResult{Skipped: true, SkipReason: "already at 0 replicas"}, nil
 	}
 
+	// Disable HPA scale-up before zeroing replicas to prevent HPA fight-back.
+	// Non-fatal: log the error and continue so workload scaling is never blocked.
+	if hpaErr := PatchHPAForDownscale(ctx, c, hpaList, deploy.Namespace, "Deployment", deploy.Name, scheduleName); hpaErr != nil {
+		logger.Error(hpaErr, "failed to patch HPA for downscale, continuing")
+	}
+
 	// Scale down
 	deploy.Annotations[constants.OriginalReplicasAnnotation] = strconv.Itoa(int(currentReplicas))
 	deploy.Annotations[constants.ManagedByAnnotation] = scheduleName
@@ -89,9 +97,15 @@ func scaleDeploymentDown(ctx context.Context, c client.Client, deploy *appsv1.De
 	}, nil
 }
 
-func scaleDeploymentUp(ctx context.Context, c client.Client, deploy *appsv1.Deployment, scheduleName, managedBy, originalReplicas string, logger logr.Logger) (*ScaleResult, error) {
-	// Skip if no original-replicas annotation (not managed by us)
+func scaleDeploymentUp(ctx context.Context, c client.Client, deploy *appsv1.Deployment, scheduleName, managedBy, originalReplicas string, hpaList *unstructured.UnstructuredList, logger logr.Logger) (*ScaleResult, error) {
+	// Skip if no original-replicas annotation (not managed by us).
+	// Still attempt HPA restore: if the controller crashed after the workload update but before
+	// RestoreHPA ran, the HPA is stuck with scaleUp disabled and dangling annotations. RestoreHPA
+	// is a no-op when the HPA has no managed-by annotation (genuine skip case).
 	if originalReplicas == "" {
+		if hpaErr := RestoreHPA(ctx, c, hpaList, deploy.Namespace, "Deployment", deploy.Name, scheduleName); hpaErr != nil {
+			logger.Error(hpaErr, "failed to restore HPA during skip check, continuing")
+		}
 		logger.V(1).Info("skipping deployment: no original-replicas annotation")
 		return &ScaleResult{Skipped: true, SkipReason: "not managed by lightsout"}, nil
 	}
@@ -123,6 +137,11 @@ func scaleDeploymentUp(ctx context.Context, c client.Client, deploy *appsv1.Depl
 		return nil, err
 	}
 
+	// Restore HPA minReplicas after replica write. Non-fatal.
+	if hpaErr := RestoreHPA(ctx, c, hpaList, deploy.Namespace, "Deployment", deploy.Name, scheduleName); hpaErr != nil {
+		logger.Error(hpaErr, "failed to restore HPA after upscale, continuing")
+	}
+
 	logger.Info("scaled up deployment", "from", 0, "to", replicas)
 	return &ScaleResult{
 		PreviousValue: "0",
@@ -130,9 +149,10 @@ func scaleDeploymentUp(ctx context.Context, c client.Client, deploy *appsv1.Depl
 	}, nil
 }
 
-// ScaleStatefulSet scales a statefulset up or down based on the period
-// scaleUp=true means restore to original replicas, scaleUp=false means scale to 0
-func ScaleStatefulSet(ctx context.Context, c client.Client, sts *appsv1.StatefulSet, scheduleName string, scaleUp bool) (*ScaleResult, error) {
+// ScaleStatefulSet scales a statefulset up or down based on the period.
+// scaleUp=true means restore to original replicas, scaleUp=false means scale to 0.
+// hpaList is the pre-fetched HPA list for the statefulset's namespace, pass nil to skip HPA handling.
+func ScaleStatefulSet(ctx context.Context, c client.Client, sts *appsv1.StatefulSet, scheduleName string, scaleUp bool, hpaList *unstructured.UnstructuredList) (*ScaleResult, error) {
 	logger := log.FromContext(ctx).WithValues("statefulset", sts.Name, "namespace", sts.Namespace)
 
 	if sts.Annotations == nil {
@@ -143,12 +163,12 @@ func ScaleStatefulSet(ctx context.Context, c client.Client, sts *appsv1.Stateful
 	originalReplicas := sts.Annotations[constants.OriginalReplicasAnnotation]
 
 	if scaleUp {
-		return scaleStatefulSetUp(ctx, c, sts, scheduleName, managedBy, originalReplicas, logger)
+		return scaleStatefulSetUp(ctx, c, sts, scheduleName, managedBy, originalReplicas, hpaList, logger)
 	}
-	return scaleStatefulSetDown(ctx, c, sts, scheduleName, managedBy, originalReplicas, logger)
+	return scaleStatefulSetDown(ctx, c, sts, scheduleName, managedBy, originalReplicas, hpaList, logger)
 }
 
-func scaleStatefulSetDown(ctx context.Context, c client.Client, sts *appsv1.StatefulSet, scheduleName, managedBy, originalReplicas string, logger logr.Logger) (*ScaleResult, error) {
+func scaleStatefulSetDown(ctx context.Context, c client.Client, sts *appsv1.StatefulSet, scheduleName, managedBy, originalReplicas string, hpaList *unstructured.UnstructuredList, logger logr.Logger) (*ScaleResult, error) {
 	// Skip if managed by different schedule
 	if managedBy != "" && managedBy != scheduleName {
 		logger.Info("skipping statefulset: managed by different schedule", "managedBy", managedBy)
@@ -175,6 +195,12 @@ func scaleStatefulSetDown(ctx context.Context, c client.Client, sts *appsv1.Stat
 		return &ScaleResult{Skipped: true, SkipReason: "already at 0 replicas"}, nil
 	}
 
+	// Disable HPA scale-up before zeroing replicas to prevent HPA fight-back.
+	// Non-fatal: log the error and continue so workload scaling is never blocked.
+	if hpaErr := PatchHPAForDownscale(ctx, c, hpaList, sts.Namespace, "StatefulSet", sts.Name, scheduleName); hpaErr != nil {
+		logger.Error(hpaErr, "failed to patch HPA for downscale, continuing")
+	}
+
 	// Scale down
 	sts.Annotations[constants.OriginalReplicasAnnotation] = strconv.Itoa(int(currentReplicas))
 	sts.Annotations[constants.ManagedByAnnotation] = scheduleName
@@ -196,9 +222,15 @@ func scaleStatefulSetDown(ctx context.Context, c client.Client, sts *appsv1.Stat
 	}, nil
 }
 
-func scaleStatefulSetUp(ctx context.Context, c client.Client, sts *appsv1.StatefulSet, scheduleName, managedBy, originalReplicas string, logger logr.Logger) (*ScaleResult, error) {
-	// Skip if no original-replicas annotation (not managed by us)
+func scaleStatefulSetUp(ctx context.Context, c client.Client, sts *appsv1.StatefulSet, scheduleName, managedBy, originalReplicas string, hpaList *unstructured.UnstructuredList, logger logr.Logger) (*ScaleResult, error) {
+	// Skip if no original-replicas annotation (not managed by us).
+	// Still attempt HPA restore: if the controller crashed after the workload update but before
+	// RestoreHPA ran, the HPA is stuck with scaleUp disabled and dangling annotations. RestoreHPA
+	// is a no-op when the HPA has no managed-by annotation (genuine skip case).
 	if originalReplicas == "" {
+		if hpaErr := RestoreHPA(ctx, c, hpaList, sts.Namespace, "StatefulSet", sts.Name, scheduleName); hpaErr != nil {
+			logger.Error(hpaErr, "failed to restore HPA during skip check, continuing")
+		}
 		logger.V(1).Info("skipping statefulset: no original-replicas annotation")
 		return &ScaleResult{Skipped: true, SkipReason: "not managed by lightsout"}, nil
 	}
@@ -228,6 +260,11 @@ func scaleStatefulSetUp(ctx context.Context, c client.Client, sts *appsv1.Statef
 
 	if err := c.Update(ctx, sts); err != nil {
 		return nil, err
+	}
+
+	// Restore HPA minReplicas after replica write. Non-fatal.
+	if hpaErr := RestoreHPA(ctx, c, hpaList, sts.Namespace, "StatefulSet", sts.Name, scheduleName); hpaErr != nil {
+		logger.Error(hpaErr, "failed to restore HPA after upscale, continuing")
 	}
 
 	logger.Info("scaled up statefulset", "from", 0, "to", replicas)

--- a/internal/controller/scaler_test.go
+++ b/internal/controller/scaler_test.go
@@ -7,7 +7,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -97,7 +99,7 @@ func TestScaleDeployment_Downscale(t *testing.T) {
 				WithObjects(tt.deployment).
 				Build()
 
-			result, err := ScaleDeployment(context.Background(), fakeClient, tt.deployment, tt.scheduleName, false)
+			result, err := ScaleDeployment(context.Background(), fakeClient, tt.deployment, tt.scheduleName, false, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -209,7 +211,7 @@ func TestScaleStatefulSet_Downscale(t *testing.T) {
 				WithObjects(tt.statefulset).
 				Build()
 
-			result, err := ScaleStatefulSet(context.Background(), fakeClient, tt.statefulset, tt.scheduleName, false)
+			result, err := ScaleStatefulSet(context.Background(), fakeClient, tt.statefulset, tt.scheduleName, false, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -330,7 +332,7 @@ func TestScaleStatefulSet_Upscale(t *testing.T) {
 				WithObjects(tt.statefulset).
 				Build()
 
-			result, err := ScaleStatefulSet(context.Background(), fakeClient, tt.statefulset, tt.scheduleName, true)
+			result, err := ScaleStatefulSet(context.Background(), fakeClient, tt.statefulset, tt.scheduleName, true, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -448,7 +450,7 @@ func TestScaleDeployment_Upscale(t *testing.T) {
 				WithObjects(tt.deployment).
 				Build()
 
-			result, err := ScaleDeployment(context.Background(), fakeClient, tt.deployment, tt.scheduleName, true)
+			result, err := ScaleDeployment(context.Background(), fakeClient, tt.deployment, tt.scheduleName, true, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -667,5 +669,236 @@ func TestScaleCronJob_Upscale(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestScaleDeploymentDown_WithHPA(t *testing.T) {
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-deploy", Namespace: "ns"},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr(int32(3))},
+	}
+	hpa := makeHPA("Deployment", "my-deploy", minReplicasPtr(2), nil)
+
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	addHPATypes(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	result, err := ScaleDeployment(context.Background(), fakeClient, deploy, "my-schedule", false, hpaList)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Skipped {
+		t.Fatal("expected deployment to be scaled, not skipped")
+	}
+
+	updated := &appsv1.Deployment{}
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-deploy"}, updated)
+	if updated.Spec.Replicas == nil || *updated.Spec.Replicas != 0 {
+		t.Errorf("expected replicas=0 after downscale")
+	}
+
+	updatedHPA := &unstructured.Unstructured{}
+	updatedHPA.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updatedHPA)
+	// minReplicas should be unchanged (we disable scaleUp instead)
+	minR, _, _ := unstructured.NestedInt64(updatedHPA.Object, "spec", "minReplicas")
+	if minR != 2 {
+		t.Errorf("expected HPA minReplicas unchanged at 2 after downscale, got %d", minR)
+	}
+	policy, _, _ := unstructured.NestedString(updatedHPA.Object, "spec", "behavior", "scaleUp", "selectPolicy")
+	if policy != hpaScaleUpDisabled {
+		t.Errorf("expected scaleUp.selectPolicy=Disabled after downscale, got %q", policy)
+	}
+	if updatedHPA.GetAnnotations()[constants.ManagedByAnnotation] != "my-schedule" {
+		t.Errorf("expected managed-by annotation set to my-schedule")
+	}
+}
+
+func TestScaleDeploymentUp_WithHPA(t *testing.T) {
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-deploy",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				constants.OriginalReplicasAnnotation: "3",
+				constants.ManagedByAnnotation:        "my-schedule",
+			},
+			Labels: map[string]string{constants.ManagedByLabel: "my-schedule"},
+		},
+		Spec: appsv1.DeploymentSpec{Replicas: ptr(int32(0))},
+	}
+	// HPA in post-downscale state: scaleUp disabled, minReplicas unchanged at 2
+	hpa := makeHPA("Deployment", "my-deploy", minReplicasPtr(2), map[string]string{
+		constants.ManagedByAnnotation:                "my-schedule",
+		constants.OriginalHPAScaleUpPolicyAnnotation: "",
+	})
+	_ = unstructured.SetNestedField(hpa.Object, hpaScaleUpDisabled, "spec", "behavior", "scaleUp", "selectPolicy")
+
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	addHPATypes(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	result, err := ScaleDeployment(context.Background(), fakeClient, deploy, "my-schedule", true, hpaList)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Skipped {
+		t.Fatal("expected deployment to be scaled up, not skipped")
+	}
+
+	updated := &appsv1.Deployment{}
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-deploy"}, updated)
+	if updated.Spec.Replicas == nil || *updated.Spec.Replicas != 3 {
+		t.Errorf("expected replicas=3 after upscale, got %v", updated.Spec.Replicas)
+	}
+
+	updatedHPA := &unstructured.Unstructured{}
+	updatedHPA.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updatedHPA)
+	// selectPolicy should be restored (removed)
+	policy, found, _ := unstructured.NestedString(updatedHPA.Object, "spec", "behavior", "scaleUp", "selectPolicy")
+	if found && policy != "" {
+		t.Errorf("expected scaleUp.selectPolicy removed after upscale, got %q", policy)
+	}
+	if updatedHPA.GetAnnotations()[constants.ManagedByAnnotation] != "" {
+		t.Error("expected managed-by annotation removed after upscale")
+	}
+	if updatedHPA.GetAnnotations()[constants.OriginalHPAScaleUpPolicyAnnotation] != "" {
+		t.Error("expected original-hpa-scale-up-policy annotation removed after upscale")
+	}
+}
+
+func TestScaleStatefulSetDown_WithHPA(t *testing.T) {
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-sts", Namespace: "ns"},
+		Spec:       appsv1.StatefulSetSpec{Replicas: ptr(int32(2))},
+	}
+	hpa := makeHPA("StatefulSet", "my-sts", minReplicasPtr(2), nil)
+
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	addHPATypes(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sts).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	result, err := ScaleStatefulSet(context.Background(), fakeClient, sts, "my-schedule", false, hpaList)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Skipped {
+		t.Fatal("expected statefulset to be scaled, not skipped")
+	}
+
+	updatedHPA := &unstructured.Unstructured{}
+	updatedHPA.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updatedHPA)
+	// minReplicas should be unchanged (we disable scaleUp instead)
+	minR, _, _ := unstructured.NestedInt64(updatedHPA.Object, "spec", "minReplicas")
+	if minR != 2 {
+		t.Errorf("expected HPA minReplicas unchanged at 2 after statefulset downscale, got %d", minR)
+	}
+	policy, _, _ := unstructured.NestedString(updatedHPA.Object, "spec", "behavior", "scaleUp", "selectPolicy")
+	if policy != hpaScaleUpDisabled {
+		t.Errorf("expected scaleUp.selectPolicy=Disabled after statefulset downscale, got %q", policy)
+	}
+}
+
+func TestScaleStatefulSetUp_WithHPA(t *testing.T) {
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-sts",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				constants.OriginalReplicasAnnotation: "2",
+				constants.ManagedByAnnotation:        "my-schedule",
+			},
+			Labels: map[string]string{constants.ManagedByLabel: "my-schedule"},
+		},
+		Spec: appsv1.StatefulSetSpec{Replicas: ptr(int32(0))},
+	}
+	// HPA in post-downscale state: scaleUp disabled, minReplicas unchanged at 2
+	hpa := makeHPA("StatefulSet", "my-sts", minReplicasPtr(2), map[string]string{
+		constants.ManagedByAnnotation:                "my-schedule",
+		constants.OriginalHPAScaleUpPolicyAnnotation: "",
+	})
+	_ = unstructured.SetNestedField(hpa.Object, hpaScaleUpDisabled, "spec", "behavior", "scaleUp", "selectPolicy")
+
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	addHPATypes(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sts).WithRuntimeObjects(hpa).Build()
+
+	hpaList := mustListHPAs(t, fakeClient)
+	result, err := ScaleStatefulSet(context.Background(), fakeClient, sts, "my-schedule", true, hpaList)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Skipped {
+		t.Fatal("expected statefulset to be scaled up, not skipped")
+	}
+
+	updatedHPA := &unstructured.Unstructured{}
+	updatedHPA.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updatedHPA)
+	// selectPolicy should be restored (removed) after upscale
+	policy, found, _ := unstructured.NestedString(updatedHPA.Object, "spec", "behavior", "scaleUp", "selectPolicy")
+	if found && policy != "" {
+		t.Errorf("expected scaleUp.selectPolicy removed after statefulset upscale, got %q", policy)
+	}
+	if updatedHPA.GetAnnotations()[constants.ManagedByAnnotation] != "" {
+		t.Error("expected managed-by annotation removed after statefulset upscale")
+	}
+}
+
+// TestScaleDeploymentUp_HPACrashWindowRecovery verifies that if the controller crashed after
+// restoring the workload but before RestoreHPA ran, a subsequent reconcile cleans up the HPA.
+// In this state the deployment has no original-replicas annotation (already restored) but the
+// HPA still has managed-by + original-hpa-scale-up-policy annotations and scaleUp=Disabled.
+func TestScaleDeploymentUp_HPACrashWindowRecovery(t *testing.T) {
+	// Simulate post-crash state: workload already restored (no lightsout annotations),
+	// but HPA still has dangling annotations from the interrupted upscale.
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-deploy", Namespace: "ns"},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr(int32(3))},
+	}
+	hpa := makeHPA("Deployment", "my-deploy", minReplicasPtr(2), map[string]string{
+		constants.ManagedByAnnotation:                "my-schedule",
+		constants.OriginalHPAScaleUpPolicyAnnotation: "",
+	})
+	_ = unstructured.SetNestedField(hpa.Object, hpaScaleUpDisabled, "spec", "behavior", "scaleUp", "selectPolicy")
+
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	addHPATypes(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(deploy).WithRuntimeObjects(hpa).Build()
+
+	// ScaleDeployment with scaleUp=true - no original-replicas annotation, so workload is
+	// skipped, but the HPA recovery path should still restore the selectPolicy.
+	hpaList := mustListHPAs(t, fakeClient)
+	result, err := ScaleDeployment(context.Background(), fakeClient, deploy, "my-schedule", true, hpaList)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Skipped {
+		t.Fatal("expected deployment to be skipped (already restored)")
+	}
+
+	updatedHPA := &unstructured.Unstructured{}
+	updatedHPA.SetGroupVersionKind(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"})
+	_ = fakeClient.Get(context.Background(), client.ObjectKey{Namespace: "ns", Name: "my-hpa"}, updatedHPA)
+
+	policy, found, _ := unstructured.NestedString(updatedHPA.Object, "spec", "behavior", "scaleUp", "selectPolicy")
+	if found && policy != "" {
+		t.Errorf("expected scaleUp.selectPolicy restored (removed) during crash recovery, got %q", policy)
+	}
+	if updatedHPA.GetAnnotations()[constants.ManagedByAnnotation] != "" {
+		t.Error("expected managed-by annotation removed from HPA after crash recovery")
+	}
+	if updatedHPA.GetAnnotations()[constants.OriginalHPAScaleUpPolicyAnnotation] != "" {
+		t.Error("expected original-hpa-scale-up-policy annotation removed from HPA after crash recovery")
 	}
 }

--- a/internal/controller/testhelpers_hpa_test.go
+++ b/internal/controller/testhelpers_hpa_test.go
@@ -1,0 +1,51 @@
+package controller
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// testScheduleName is a reusable schedule name for HPA unit tests.
+const testScheduleName = "my-schedule"
+
+// makeHPA creates an unstructured HPA for testing.
+// minReplicas=nil means the field is absent (Kubernetes default=1).
+func makeHPA(targetKind, targetName string, minReplicas *int64, annotations map[string]string) *unstructured.Unstructured {
+	hpa := &unstructured.Unstructured{}
+	hpa.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "autoscaling",
+		Version: "v2",
+		Kind:    "HorizontalPodAutoscaler",
+	})
+	hpa.SetNamespace("ns")
+	hpa.SetName("my-hpa")
+	if annotations != nil {
+		hpa.SetAnnotations(annotations)
+	}
+	_ = unstructured.SetNestedField(hpa.Object, targetKind, "spec", "scaleTargetRef", "kind")
+	_ = unstructured.SetNestedField(hpa.Object, targetName, "spec", "scaleTargetRef", "name")
+	if minReplicas != nil {
+		_ = unstructured.SetNestedField(hpa.Object, *minReplicas, "spec", "minReplicas")
+	}
+	return hpa
+}
+
+func minReplicasPtr(v int64) *int64 { return &v }
+
+// addHPATypes registers autoscaling/v2 HPA types into an existing scheme.
+func addHPATypes(s *runtime.Scheme) {
+	s.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler",
+	}, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(schema.GroupVersionKind{
+		Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscalerList",
+	}, &unstructured.UnstructuredList{})
+}
+
+// hpaScheme returns a scheme with only HPA types registered.
+func hpaScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	addHPATypes(s)
+	return s
+}

--- a/test/e2e/hpa_test.go
+++ b/test/e2e/hpa_test.go
@@ -1,0 +1,507 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gjorgji-ts/lightsout/test/utils"
+)
+
+var _ = Describe("HPA Integration", Ordered, func() {
+	const (
+		scheduleNamespace = "lightsout-system"
+		testNamespace     = "test-hpa-integration"
+		scheduleName      = "test-hpa-schedule"
+	)
+
+	BeforeAll(func() {
+		By("creating test namespace")
+		cmd := exec.Command("kubectl", "create", "ns", testNamespace)
+		_, _ = utils.Run(cmd) // Ignore error if exists
+
+		By("creating hpa-deploy deployment with 3 replicas")
+		createDeployment(testNamespace, "hpa-deploy", 3)
+
+		By("creating HPA targeting hpa-deploy")
+		hpaYAML := fmt.Sprintf(`
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: hpa-deploy
+  namespace: %s
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: hpa-deploy
+  minReplicas: 2
+  maxReplicas: 6
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 60
+`, testNamespace)
+
+		hpaFile := "/tmp/test-hpa.yaml"
+		err := os.WriteFile(hpaFile, []byte(hpaYAML), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd = exec.Command("kubectl", "apply", "-f", hpaFile)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		By("cleaning up test resources")
+		cmd := exec.Command("kubectl", "delete", "lightsoutschedule", scheduleName, "-n", scheduleNamespace, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+		cmd = exec.Command("kubectl", "delete", "ns", testNamespace, "--ignore-not-found")
+		_, _ = utils.Run(cmd)
+	})
+
+	It("downscale disables HPA scaleUp to prevent fight-back", func() {
+		By("creating a LightsOutSchedule in downscale period")
+		scheduleYAML := fmt.Sprintf(`
+apiVersion: lightsout.techsupport.mk/v1alpha1
+kind: LightsOutSchedule
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  upscale: "0 0 31 12 *"
+  downscale: "0 0 1 1 *"
+  timezone: "UTC"
+  namespaces:
+    - %s
+`, scheduleName, scheduleNamespace, testNamespace)
+
+		scheduleFile := "/tmp/test-hpa-schedule.yaml"
+		err := os.WriteFile(scheduleFile, []byte(scheduleYAML), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd := exec.Command("kubectl", "apply", "-f", scheduleFile)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for HPA scaleUp to be disabled")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "hpa", "hpa-deploy", "-n", testNamespace,
+				"-o", "jsonpath={.spec.behavior.scaleUp.selectPolicy}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("Disabled"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("waiting for deployment to be scaled down to 0")
+		Eventually(func(g Gomega) {
+			replicas := getDeploymentReplicas(testNamespace, "hpa-deploy")
+			g.Expect(replicas).To(Equal("0"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying HPA minReplicas is unchanged at 2")
+		cmd = exec.Command("kubectl", "get", "hpa", "hpa-deploy", "-n", testNamespace,
+			"-o", "jsonpath={.spec.minReplicas}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(Equal("2"), "HPA minReplicas should remain unchanged at 2")
+
+		By("verifying HPA original-hpa-scale-up-policy annotation is set")
+		cmd = exec.Command("kubectl", "get", "hpa", "hpa-deploy", "-n", testNamespace,
+			"-o", fmt.Sprintf("jsonpath={.metadata.annotations['%s']}", escapeAnnotationKey("lightsout.techsupport.mk/original-hpa-scale-up-policy")))
+		output, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		// Empty string means field was absent originally (default behaviour)
+		Expect(output).To(BeEmpty(), "HPA original-hpa-scale-up-policy annotation should be empty (field was absent)")
+	})
+
+	It("upscale restores HPA scaleUp policy", func() {
+		By("updating schedule to upscale period")
+		scheduleYAML := fmt.Sprintf(`
+apiVersion: lightsout.techsupport.mk/v1alpha1
+kind: LightsOutSchedule
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  upscale: "0 0 1 1 *"
+  downscale: "0 0 31 12 *"
+  timezone: "UTC"
+  namespaces:
+    - %s
+`, scheduleName, scheduleNamespace, testNamespace)
+
+		scheduleFile := "/tmp/test-hpa-schedule.yaml"
+		err := os.WriteFile(scheduleFile, []byte(scheduleYAML), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd := exec.Command("kubectl", "apply", "-f", scheduleFile)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for HPA scaleUp to be re-enabled (selectPolicy no longer Disabled)")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "hpa", "hpa-deploy", "-n", testNamespace,
+				"-o", "jsonpath={.spec.behavior.scaleUp.selectPolicy}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).NotTo(Equal("Disabled"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("waiting for deployment to be restored to 3 replicas")
+		Eventually(func(g Gomega) {
+			replicas := getDeploymentReplicas(testNamespace, "hpa-deploy")
+			g.Expect(replicas).To(Equal("3"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying HPA minReplicas remains at 2 (was never changed)")
+		cmd = exec.Command("kubectl", "get", "hpa", "hpa-deploy", "-n", testNamespace,
+			"-o", "jsonpath={.spec.minReplicas}")
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(Equal("2"), "HPA minReplicas should remain 2")
+
+		By("verifying lightsout annotations are removed from HPA")
+		cmd = exec.Command("kubectl", "get", "hpa", "hpa-deploy", "-n", testNamespace,
+			"-o", fmt.Sprintf("jsonpath={.metadata.annotations['%s']}", escapeAnnotationKey("lightsout.techsupport.mk/original-hpa-scale-up-policy")))
+		output, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(BeEmpty(), "HPA original-hpa-scale-up-policy annotation should be removed after upscale")
+
+		cmd = exec.Command("kubectl", "get", "hpa", "hpa-deploy", "-n", testNamespace,
+			"-o", fmt.Sprintf("jsonpath={.metadata.annotations['%s']}", escapeAnnotationKey("lightsout.techsupport.mk/managed-by")))
+		output, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(BeEmpty(), "HPA managed-by annotation should be removed after upscale")
+	})
+
+	It("workload without HPA scales normally", func() {
+		By("creating no-hpa-deploy deployment with no HPA")
+		createDeployment(testNamespace, "no-hpa-deploy", 2)
+
+		By("applying a schedule in downscale period")
+		scheduleYAML := fmt.Sprintf(`
+apiVersion: lightsout.techsupport.mk/v1alpha1
+kind: LightsOutSchedule
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  upscale: "0 0 31 12 *"
+  downscale: "0 0 1 1 *"
+  timezone: "UTC"
+  namespaces:
+    - %s
+`, scheduleName, scheduleNamespace, testNamespace)
+
+		scheduleFile := "/tmp/test-hpa-schedule.yaml"
+		err := os.WriteFile(scheduleFile, []byte(scheduleYAML), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd := exec.Command("kubectl", "apply", "-f", scheduleFile)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for no-hpa-deploy to be scaled down to 0")
+		Eventually(func(g Gomega) {
+			replicas := getDeploymentReplicas(testNamespace, "no-hpa-deploy")
+			g.Expect(replicas).To(Equal("0"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying no-hpa-deploy has original-replicas annotation set")
+		verifyDeploymentAnnotation(testNamespace, "no-hpa-deploy", "lightsout.techsupport.mk/original-replicas", "2")
+
+		By("restoring schedule to upscale period to clean up state")
+		scheduleYAML = fmt.Sprintf(`
+apiVersion: lightsout.techsupport.mk/v1alpha1
+kind: LightsOutSchedule
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  upscale: "0 0 1 1 *"
+  downscale: "0 0 31 12 *"
+  timezone: "UTC"
+  namespaces:
+    - %s
+`, scheduleName, scheduleNamespace, testNamespace)
+
+		err = os.WriteFile(scheduleFile, []byte(scheduleYAML), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd = exec.Command("kubectl", "apply", "-f", scheduleFile)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("user-managed HPA with scaleUp disabled is skipped", func() {
+		By("creating user-disabled-deploy deployment")
+		createDeployment(testNamespace, "user-disabled-deploy", 2)
+
+		By("creating HPA with user-managed scaleUp.selectPolicy=Disabled (no lightsout annotations)")
+		hpaYAML := fmt.Sprintf(`
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: user-disabled-deploy
+  namespace: %s
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: user-disabled-deploy
+  minReplicas: 1
+  maxReplicas: 5
+  behavior:
+    scaleUp:
+      selectPolicy: Disabled
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 60
+`, testNamespace)
+
+		hpaFile := "/tmp/test-user-disabled-hpa.yaml"
+		err := os.WriteFile(hpaFile, []byte(hpaYAML), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd := exec.Command("kubectl", "apply", "-f", hpaFile)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("applying a schedule in downscale period")
+		scheduleYAML := fmt.Sprintf(`
+apiVersion: lightsout.techsupport.mk/v1alpha1
+kind: LightsOutSchedule
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  upscale: "0 0 31 12 *"
+  downscale: "0 0 1 1 *"
+  timezone: "UTC"
+  namespaces:
+    - %s
+`, scheduleName, scheduleNamespace, testNamespace)
+
+		scheduleFile := "/tmp/test-hpa-schedule.yaml"
+		err = os.WriteFile(scheduleFile, []byte(scheduleYAML), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd = exec.Command("kubectl", "apply", "-f", scheduleFile)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for reconciliation to run (deployment scaled to 0 by LightsOut)")
+		Eventually(func(g Gomega) {
+			replicas := getDeploymentReplicas(testNamespace, "user-disabled-deploy")
+			g.Expect(replicas).To(Equal("0"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("verifying HPA has no lightsout managed-by annotation (LightsOut skipped it)")
+		cmd = exec.Command("kubectl", "get", "hpa", "user-disabled-deploy", "-n", testNamespace,
+			"-o", fmt.Sprintf("jsonpath={.metadata.annotations['%s']}", escapeAnnotationKey("lightsout.techsupport.mk/managed-by")))
+		output, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(BeEmpty(), "HPA managed-by annotation should not be set for user-managed disabled HPA")
+
+		By("verifying HPA original-hpa-scale-up-policy annotation is absent")
+		cmd = exec.Command("kubectl", "get", "hpa", "user-disabled-deploy", "-n", testNamespace,
+			"-o", fmt.Sprintf("jsonpath={.metadata.annotations['%s']}", escapeAnnotationKey("lightsout.techsupport.mk/original-hpa-scale-up-policy")))
+		output, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(BeEmpty(), "HPA original-hpa-scale-up-policy annotation should not be set for user-managed disabled HPA")
+
+		By("verifying HPA selectPolicy remains Disabled (not modified by LightsOut)")
+		cmd = exec.Command("kubectl", "get", "hpa", "user-disabled-deploy", "-n", testNamespace,
+			"-o", "jsonpath={.spec.behavior.scaleUp.selectPolicy}")
+		output, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output).To(Equal("Disabled"), "HPA selectPolicy should remain Disabled")
+	})
+
+	It("handles autoscaling/v1 HPA (discoverable via v2 API)", func() {
+		// autoscaling/v1 HPAs are stored internally as v2 on k8s 1.23+ and served
+		// across both API versions. LightsOut lists autoscaling/v2, so it will find
+		// and patch v1-created HPAs transparently.
+		By("creating v1-hpa-deploy deployment")
+		createDeployment(testNamespace, "v1-hpa-deploy", 3)
+
+		By("creating HPA using autoscaling/v1")
+		hpaYAML := fmt.Sprintf(`
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: v1-hpa-deploy
+  namespace: %s
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: v1-hpa-deploy
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 60
+`, testNamespace)
+
+		hpaFile := "/tmp/test-v1-hpa.yaml"
+		err := os.WriteFile(hpaFile, []byte(hpaYAML), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd := exec.Command("kubectl", "apply", "-f", hpaFile)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		scheduleFile := "/tmp/test-hpa-schedule.yaml"
+
+		// The previous test left the schedule in downscale state with the same cron spec we
+		// would use here. Applying an identical spec is a no-op (no generation change), so
+		// GenerationChangedPredicate would suppress the watch event and no reconcile would
+		// fire for the newly-created v1-hpa-deploy workload. Force a fresh reconcile by
+		// cycling through upscale first, then switching back to downscale.
+		By("cycling schedule to upscale to force a generation change")
+		upscaleYAML := fmt.Sprintf(`
+apiVersion: lightsout.techsupport.mk/v1alpha1
+kind: LightsOutSchedule
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  upscale: "0 0 1 1 *"
+  downscale: "0 0 31 12 *"
+  timezone: "UTC"
+  namespaces:
+    - %s
+`, scheduleName, scheduleNamespace, testNamespace)
+		err = os.WriteFile(scheduleFile, []byte(upscaleYAML), 0644)
+		Expect(err).NotTo(HaveOccurred())
+		cmd = exec.Command("kubectl", "apply", "-f", scheduleFile)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("applying a schedule in downscale period")
+		scheduleYAML := fmt.Sprintf(`
+apiVersion: lightsout.techsupport.mk/v1alpha1
+kind: LightsOutSchedule
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  upscale: "0 0 31 12 *"
+  downscale: "0 0 1 1 *"
+  timezone: "UTC"
+  namespaces:
+    - %s
+`, scheduleName, scheduleNamespace, testNamespace)
+		err = os.WriteFile(scheduleFile, []byte(scheduleYAML), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd = exec.Command("kubectl", "apply", "-f", scheduleFile)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for HPA scaleUp to be disabled (discovered via v2 API)")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "hpa", "v1-hpa-deploy", "-n", testNamespace,
+				"-o", "jsonpath={.spec.behavior.scaleUp.selectPolicy}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("Disabled"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("waiting for deployment to be scaled down to 0")
+		Eventually(func(g Gomega) {
+			replicas := getDeploymentReplicas(testNamespace, "v1-hpa-deploy")
+			g.Expect(replicas).To(Equal("0"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		// The downscale reconcile patches the HPA via the API server, but the upscale
+		// reconcile reads HPAs from the informer cache which updates asynchronously via
+		// watch events. If the upscale schedule is applied before the cache reflects the
+		// managed-by annotation, RestoreHPA sees a stale HPA, no-ops silently, and the
+		// RequeueAfter is set to months with no retry. Confirming the annotation is set
+		// via kubectl (API server) and then checking it consistently for a few seconds
+		// ensures the informer has processed the watch event before the upscale reconcile.
+		By("confirming HPA managed-by annotation is set (cache settled before upscale)")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "hpa", "v1-hpa-deploy", "-n", testNamespace,
+				"-o", fmt.Sprintf("jsonpath={.metadata.annotations['%s']}", escapeAnnotationKey("lightsout.techsupport.mk/managed-by")))
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).NotTo(BeEmpty())
+		}, 30*time.Second, time.Second).Should(Succeed())
+		Consistently(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "hpa", "v1-hpa-deploy", "-n", testNamespace,
+				"-o", "jsonpath={.spec.behavior.scaleUp.selectPolicy}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).To(Equal("Disabled"))
+		}, 3*time.Second, time.Second).Should(Succeed())
+
+		By("switching schedule to upscale period")
+		scheduleYAML = fmt.Sprintf(`
+apiVersion: lightsout.techsupport.mk/v1alpha1
+kind: LightsOutSchedule
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  upscale: "0 0 1 1 *"
+  downscale: "0 0 31 12 *"
+  timezone: "UTC"
+  namespaces:
+    - %s
+`, scheduleName, scheduleNamespace, testNamespace)
+
+		err = os.WriteFile(scheduleFile, []byte(scheduleYAML), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		cmd = exec.Command("kubectl", "apply", "-f", scheduleFile)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for HPA scaleUp to be re-enabled after upscale")
+		Eventually(func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "hpa", "v1-hpa-deploy", "-n", testNamespace,
+				"-o", "jsonpath={.spec.behavior.scaleUp.selectPolicy}")
+			output, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(output).NotTo(Equal("Disabled"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("waiting for deployment to be restored to 3 replicas")
+		Eventually(func(g Gomega) {
+			replicas := getDeploymentReplicas(testNamespace, "v1-hpa-deploy")
+			g.Expect(replicas).To(Equal("3"))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+	})
+})


### PR DESCRIPTION
## Motivation

HPA managed deployments were being scaled down by LightsOut but the HPA would immediately fight back, restoring replicas to `minReplicas`. The original approach of setting `minReplicas=0` was invalid. Kubernetes only allows `minReplicas=0` with Object or External metrics, Resource (CPU) metrics are rejected by the API server.

## Changes

Rather than patching `minReplicas`, LightsOut now sets `spec.behavior.scaleUp.selectPolicy: Disabled` on HPAs that target a managed workload. This prevents the HPA from acting while LightsOut holds the deployment at 0, without requiring any specific metric type configuration.

**Strategy:**
- **Downscale**: read the current `scaleUp.selectPolicy`, store it in an annotation (`lightsout.techsupport.mk/original-hpa-scale-up-policy`), then set `selectPolicy: Disabled`
- **Upscale**: restore the original policy (or remove the field if it was absent) and remove the LightsOut annotations
- **Skip conditions**: HPAs already at `selectPolicy: Disabled` without a `managed-by` annotation are treated as user-managed and left untouched, HPAs managed by a different schedule are skipped

## Testing

- Unit tests: `internal/controller/hpa_test.go` (patch/restore logic, skip conditions, policy preservation), `internal/controller/scaler_test.go` (HPA wired into scale-down/up paths for Deployments and StatefulSets, crash window recovery)
- e2e: `test/e2e/hpa_test.go` — 5 scenarios run against a live cluster:
  1. Downscale sets `selectPolicy: Disabled`, leaves `minReplicas` unchanged
  2. Upscale restores original policy and removes annotations
  3. Workload without an HPA scales normally (no HPA-related side effects)
  4. User-managed HPA with `selectPolicy: Disabled` already set is skipped (no annotations stamped)
  5. v1 HPA (`autoscaling/v1`) is handled correctly via internal v2 storage
- Manual: verified against local Kind demo — `api-server` HPA correctly enters `ScalingDisabled` state with pods at 0, then fully restores on upscale

## Checklist

- [x] Tests added / updated
- [x] Docs updated if behaviour changed
- [x] `make lint` passes
- [x] `make test` passes
- [x] `make manifests generate` run if API types changed
- [x] `make helm-crds` run if CRDs changed
